### PR TITLE
merge(#30)auth msa 내부 api 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Gradle
 .gradle/
 **/build/
+.gradle-local/
+**/*.lck
+**/*.part
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/finda-auth/build.gradle.kts
+++ b/finda-auth/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     implementation(Dependencies.GRPC_STUB)
     implementation(Dependencies.PROTOBUF_JAVA)
     compileOnly(Dependencies.JAVAX_ANNOTATION)
+    implementation(Dependencies.GRPC_CLIENT)
+    implementation(Dependencies.GRPC_PROTOBUF)
+    implementation(Dependencies.GRPC_STUB)
 }
 
 protobuf {

--- a/finda-auth/build.gradle.kts
+++ b/finda-auth/build.gradle.kts
@@ -38,8 +38,6 @@ dependencies {
     implementation(Dependencies.SPRING_VALIDITY)
     implementation(Dependencies.LIQUIBASE)
     implementation(Dependencies.GRPC_SERVER)
-    implementation(Dependencies.GRPC_PROTOBUF)
-    implementation(Dependencies.GRPC_STUB)
     implementation(Dependencies.PROTOBUF_JAVA)
     compileOnly(Dependencies.JAVAX_ANNOTATION)
     implementation(Dependencies.GRPC_CLIENT)

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/StudentGrpcService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/StudentGrpcService.kt
@@ -1,6 +1,7 @@
 package finda.findaauth.adapter.`in`.grpc
 
 import com.google.protobuf.Empty
+import finda.error.FindaException
 import finda.findaauth.application.exception.student.StudentNotFoundException
 import finda.findaauth.application.exception.user.UserNotFoundException
 import finda.findaauth.application.port.out.student.StudentQueryPort
@@ -105,6 +106,8 @@ class StudentGrpcService(
             observer.onNext(block())
             observer.onCompleted()
         } catch (e: StatusRuntimeException) {
+            observer.onError(e)
+        } catch (e: FindaException){
             observer.onError(e)
         } catch (e: Exception) {
             observer.onError(

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/StudentGrpcService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/StudentGrpcService.kt
@@ -1,0 +1,118 @@
+package finda.findaauth.adapter.`in`.grpc
+
+import com.google.protobuf.Empty
+import finda.findaauth.application.exception.student.StudentNotFoundException
+import finda.findaauth.application.exception.user.UserNotFoundException
+import finda.findaauth.application.port.out.student.StudentQueryPort
+import finda.findaauth.application.port.out.user.UserQueryPort
+import finda.findaauth.domain.student.model.Student
+import finda.findaauth.domain.user.model.User
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.grpc.stub.StreamObserver
+import net.devh.boot.grpc.server.service.GrpcService
+import java.util.UUID
+
+@GrpcService
+class StudentGrpcService(
+    private val studentQueryPort: StudentQueryPort,
+    private val userQueryPort: UserQueryPort
+) : StudentServiceGrpc.StudentServiceImplBase() {
+    override fun getStudentsInfo(
+        request: UserListRequest,
+        responseObserver: StreamObserver<StudentsInfoResponse>
+    ) = handleGrpc(responseObserver) {
+        val studentsInfo = request.userIdsList
+            .map(::parseUUID)
+            .map { userId ->
+                val student = studentQueryPort.findStudentByUserId(userId)
+                    ?: throw StudentNotFoundException
+                val user = userQueryPort.findById(userId)
+                    ?: throw UserNotFoundException
+                mapStudentInfo(user, student)
+            }
+
+        StudentsInfoResponse.newBuilder()
+            .addAllStudentsInfo(studentsInfo)
+            .build()
+    }
+
+    override fun getStudentInfo(
+        request: UserRequest,
+        responseObserver: StreamObserver<UserIdAndUserInfo>
+    ) = handleGrpc(responseObserver) {
+        val userId = parseUUID(request.userId)
+        val student = studentQueryPort.findStudentByUserId(userId)
+            ?: throw StudentNotFoundException
+        val user = userQueryPort.findById(userId)
+            ?: throw UserNotFoundException
+
+        mapStudentInfo(user, student)
+    }
+
+    override fun getStudentsAllInfo(
+        request: Empty,
+        responseObserver: StreamObserver<StudentsInfoResponse>
+    ) = handleGrpc(responseObserver) {
+        val studentsInfo = studentQueryPort.findAll()
+            .mapNotNull { student ->
+                val user = userQueryPort.findById(student.userId) ?: return@mapNotNull null
+                mapStudentInfo(user, student)
+            }
+
+        StudentsInfoResponse.newBuilder()
+            .addAllStudentsInfo(studentsInfo)
+            .build()
+    }
+
+    private fun mapStudentInfo(user: User, student: Student): UserIdAndUserInfo {
+        val authority = when (user.authority) {
+            finda.security.passport.model.Authority.STUDENT -> Authority.STUDENT
+            finda.security.passport.model.Authority.TEACHER -> Authority.TEACHER
+        }
+
+        return UserIdAndUserInfo.newBuilder()
+            .setUserId(user.id.toString())
+            .setUserInfo(
+                UserInfo.newBuilder()
+                    .setName(user.name)
+                    .setEmail(user.email)
+                    .setAuthority(authority)
+                    .setGrade(student.grade)
+                    .setClassNum(student.classNum)
+                    .setNum(student.num)
+                    .setTotalVolunteerTime(student.totalVolunteerTime)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun parseUUID(value: String): UUID =
+        try {
+            UUID.fromString(value)
+        } catch (e: IllegalArgumentException) {
+            throw Status.INVALID_ARGUMENT
+                .withDescription("Invalid UUID format")
+                .withCause(e)
+                .asRuntimeException()
+        }
+
+    private fun <T> handleGrpc(
+        observer: StreamObserver<T>,
+        block: () -> T
+    ) {
+        try {
+            observer.onNext(block())
+            observer.onCompleted()
+        } catch (e: StatusRuntimeException) {
+            observer.onError(e)
+        } catch (e: Exception) {
+            observer.onError(
+                Status.INTERNAL
+                    .withDescription("Internal server error")
+                    .withCause(e)
+                    .asRuntimeException()
+            )
+        }
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/TeacherGrpcService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/TeacherGrpcService.kt
@@ -1,0 +1,117 @@
+package finda.findaauth.adapter.`in`.grpc
+
+import com.google.protobuf.Empty
+import finda.findaauth.application.exception.teacher.TeacherNotFoundException
+import finda.findaauth.application.exception.user.UserNotFoundException
+import finda.findaauth.application.port.out.teacher.TeacherQueryPort
+import finda.findaauth.application.port.out.user.UserQueryPort
+import finda.findaauth.domain.teacher.model.Teacher
+import finda.findaauth.domain.user.model.User
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.grpc.stub.StreamObserver
+import net.devh.boot.grpc.server.service.GrpcService
+import java.util.UUID
+
+@GrpcService
+class TeacherGrpcService(
+    private val teacherQueryPort: TeacherQueryPort,
+    private val userQueryPort: UserQueryPort
+) : TeacherServiceGrpc.TeacherServiceImplBase() {
+    override fun getTeachersInfo(
+        request: UserListRequest,
+        responseObserver: StreamObserver<TeachersInfoResponse>
+    ) = handleGrpc(responseObserver) {
+        val teachersInfo = request.userIdsList
+            .map(::parseUUID)
+            .mapNotNull { userId ->
+                val teacher = teacherQueryPort.findTeacherByUserId(userId) ?: return@mapNotNull null
+                val user = userQueryPort.findById(userId) ?: return@mapNotNull null
+                mapTeacherInfo(user, teacher)
+            }
+
+        TeachersInfoResponse.newBuilder()
+            .addAllTeachersInfo(teachersInfo)
+            .build()
+    }
+
+    override fun getTeacherInfo(
+        request: UserRequest,
+        responseObserver: StreamObserver<UserIdAndUserInfo>
+    ) = handleGrpc(responseObserver) {
+        val userId = parseUUID(request.userId)
+        val teacher = teacherQueryPort.findTeacherByUserId(userId)
+            ?: throw TeacherNotFoundException
+        val user = userQueryPort.findById(userId)
+            ?: throw UserNotFoundException
+
+        mapTeacherInfo(user, teacher)
+    }
+
+    override fun getTeachersAllInfo(
+        request: Empty,
+        responseObserver: StreamObserver<TeachersInfoResponse>
+    ) = handleGrpc(responseObserver) {
+        val teachersInfo = teacherQueryPort.findAll()
+            .mapNotNull { teacher ->
+                val user = userQueryPort.findById(teacher.userId) ?: return@mapNotNull null
+                mapTeacherInfo(user, teacher)
+            }
+
+        TeachersInfoResponse.newBuilder()
+            .addAllTeachersInfo(teachersInfo)
+            .build()
+    }
+
+    private fun mapTeacherInfo(user: User, teacher: Teacher): UserIdAndUserInfo {
+        val authority = when (user.authority) {
+            finda.security.passport.model.Authority.STUDENT -> Authority.STUDENT
+            finda.security.passport.model.Authority.TEACHER -> Authority.TEACHER
+        }
+
+        return UserIdAndUserInfo.newBuilder()
+            .setUserId(user.id.toString())
+            .setUserInfo(
+                UserInfo.newBuilder()
+                    .setName(user.name)
+                    .setEmail(user.email)
+                    .setAuthority(authority)
+                    .setTeacherInfo(
+                        TeacherInfo.newBuilder()
+                            .setTeacherId(teacher.id.toString())
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+    }
+
+    private fun parseUUID(value: String): UUID =
+        try {
+            UUID.fromString(value)
+        } catch (e: IllegalArgumentException) {
+            throw Status.INVALID_ARGUMENT
+                .withDescription("Invalid UUID format")
+                .withCause(e)
+                .asRuntimeException()
+        }
+
+    private fun <T> handleGrpc(
+        observer: StreamObserver<T>,
+        block: () -> T
+    ) {
+        try {
+            observer.onNext(block())
+            observer.onCompleted()
+        } catch (e: StatusRuntimeException) {
+            observer.onError(e)
+        } catch (e: Exception) {
+            observer.onError(
+                Status.INTERNAL
+                    .withDescription("Internal server error")
+                    .withCause(e)
+                    .asRuntimeException()
+            )
+        }
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/TeacherGrpcService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/grpc/TeacherGrpcService.kt
@@ -40,10 +40,10 @@ class TeacherGrpcService(
         responseObserver: StreamObserver<UserIdAndUserInfo>
     ) = handleGrpc(responseObserver) {
         val userId = parseUUID(request.userId)
-        val teacher = teacherQueryPort.findTeacherByUserId(userId)
-            ?: throw TeacherNotFoundException
         val user = userQueryPort.findById(userId)
             ?: throw UserNotFoundException
+        val teacher = teacherQueryPort.findTeacherByUserId(userId)
+            ?: throw TeacherNotFoundException
 
         mapTeacherInfo(user, teacher)
     }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import finda.findaauth.adapter.out.persistence.user.repository.UserRepository
 import finda.findaauth.application.port.out.student.StudentCommandPort
 import finda.findaauth.application.port.out.student.StudentQueryPort
 import finda.findaauth.domain.student.model.Student
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import java.util.*
 
@@ -31,5 +32,19 @@ class StudentPersistenceAdapter(
 
     override fun existsByStudentNumber(grade: Int, classNum: Int, num: Int): Boolean {
         return studentRepository.existsByGradeAndClassNumAndNum(grade, classNum, num)
+    }
+
+    override fun findStudentByUserId(userId: UUID): Student? {
+        val userEntity = userRepository.findByIdOrNull(userId) ?: return null
+        val student = studentRepository.findByUser(userEntity).orElse(null) ?: return null
+        return studentMapper.toDomain(student)
+    }
+
+    override fun findAllByUserIds(userIds: List<UUID>): List<Student?> {
+        return userIds.map { findStudentByUserId(it) }
+    }
+
+    override fun findAll(): List<Student> {
+        return studentRepository.findAll().map(studentMapper::toDomain).toList()
     }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
@@ -4,7 +4,8 @@ import finda.findaauth.adapter.out.persistence.student.entity.StudentJpaEntity
 import finda.findaauth.adapter.out.persistence.user.entity.UserJpaEntity
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
-import java.util.*
+import java.util.UUID
+import java.util.Optional
 
 @Repository
 interface StudentRepository : CrudRepository<StudentJpaEntity, UUID> {

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
@@ -4,7 +4,7 @@ import finda.findaauth.adapter.out.persistence.student.entity.StudentJpaEntity
 import finda.findaauth.adapter.out.persistence.user.entity.UserJpaEntity
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
-import java.util.UUID
+import java.util.*
 
 @Repository
 interface StudentRepository : CrudRepository<StudentJpaEntity, UUID> {
@@ -13,4 +13,6 @@ interface StudentRepository : CrudRepository<StudentJpaEntity, UUID> {
     fun existsByUserId(userId: UUID): Boolean
 
     fun existsByGradeAndClassNumAndNum(grade: Int, classNum: Int, num: Int): Boolean
+
+    fun findByUser(user: UserJpaEntity): Optional<StudentJpaEntity>
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
@@ -7,6 +7,7 @@ import finda.findaauth.adapter.out.persistence.user.repository.UserRepository
 import finda.findaauth.application.port.out.teacher.TeacherCommandPort
 import finda.findaauth.application.port.out.teacher.TeacherQueryPort
 import finda.findaauth.domain.teacher.model.Teacher
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -30,5 +31,19 @@ class TeacherPersistenceAdapter(
 
     override fun existsByUserId(userId: UUID): Boolean {
         return teacherRepository.existsByUserId(userId)
+    }
+
+    override fun findTeacherByUserId(userId: UUID): Teacher? {
+        val userEntity = userRepository.findByIdOrNull(userId) ?: return null
+        val teacher = teacherRepository.findByUser(userEntity).orElse(null) ?: return null
+        return teacherMapper.toDomain(teacher)
+    }
+
+    override fun findAllByUserIds(userIds: List<UUID>): List<Teacher?> {
+        return userIds.map { findTeacherByUserId(it) }
+    }
+
+    override fun findAll(): List<Teacher> {
+        return teacherRepository.findAll().map(teacherMapper::toDomain).toList()
     }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/repository/TeacherRepository.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/repository/TeacherRepository.kt
@@ -4,10 +4,12 @@ import finda.findaauth.adapter.out.persistence.teacher.entity.TeacherJpaEntity
 import finda.findaauth.adapter.out.persistence.user.entity.UserJpaEntity
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 import java.util.UUID
 
 @Repository
 interface TeacherRepository : CrudRepository<TeacherJpaEntity, UUID> {
     fun existsByUser(user: UserJpaEntity): Boolean
     fun existsByUserId(userId: UUID): Boolean
+    fun findByUser(user: UserJpaEntity): Optional<TeacherJpaEntity>
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/exception/student/StudentNotFoundException.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/exception/student/StudentNotFoundException.kt
@@ -4,5 +4,5 @@ import finda.error.ErrorCode
 import finda.error.FindaException
 
 object StudentNotFoundException : FindaException(
-    ErrorCode.USER_NOT_FOUND
+    ErrorCode.STUDENT_NOT_FOUND
 )

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/exception/student/StudentNotFoundException.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/exception/student/StudentNotFoundException.kt
@@ -1,0 +1,8 @@
+package finda.findaauth.application.exception.student
+
+import finda.error.ErrorCode
+import finda.error.FindaException
+
+object StudentNotFoundException : FindaException(
+    ErrorCode.USER_NOT_FOUND
+)

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/exception/teacher/TeacherNotFoundException.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/exception/teacher/TeacherNotFoundException.kt
@@ -1,0 +1,8 @@
+package finda.findaauth.application.exception.teacher
+
+import finda.error.ErrorCode
+import finda.error.FindaException
+
+object TeacherNotFoundException : FindaException(
+    ErrorCode.TEACHER_NOT_FOUND
+)

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
@@ -1,9 +1,16 @@
 package finda.findaauth.application.port.out.student
 
+import finda.findaauth.domain.student.model.Student
 import java.util.UUID
 
 interface StudentQueryPort {
     fun existsByUserId(userId: UUID): Boolean
 
     fun existsByStudentNumber(grade: Int, classNum: Int, num: Int): Boolean
+
+    fun findStudentByUserId(userId: UUID): Student?
+
+    fun findAllByUserIds(userIds: List<UUID>): List<Student?>
+
+    fun findAll(): List<Student>
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/teacher/TeacherQueryPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/teacher/TeacherQueryPort.kt
@@ -1,7 +1,11 @@
 package finda.findaauth.application.port.out.teacher
 
+import finda.findaauth.domain.teacher.model.Teacher
 import java.util.UUID
 
 interface TeacherQueryPort {
     fun existsByUserId(userId: UUID): Boolean
+    fun findTeacherByUserId(userId: UUID): Teacher?
+    fun findAllByUserIds(userIds: List<UUID>): List<Teacher?>
+    fun findAll(): List<Teacher>
 }

--- a/finda-auth/src/main/proto/auth.proto
+++ b/finda-auth/src/main/proto/auth.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-// 양쪽 서버가 같은 인터페이스로 통신해야하기에 controller 명세
 package auth;
 
 option java_package = "finda.findaauth.adapter.in.grpc";
@@ -26,4 +25,13 @@ message DeviceTokenResponse {
 
 message DeviceTokenListResponse {
   repeated DeviceTokenResponse tokens = 1;
+}
+
+message UserDevice {
+  string user_id = 1;
+  repeated DeviceTokenResponse devices = 2;
+}
+
+message UserDeviceListResponse {
+  repeated UserDevice users = 1;
 }

--- a/finda-auth/src/main/proto/student.proto
+++ b/finda-auth/src/main/proto/student.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package auth;
+
+import "auth.proto";
+import "google/protobuf/empty.proto";
+
+option java_package = "finda.findaauth.adapter.in.grpc";
+option java_multiple_files = true;
+
+service StudentService {
+  rpc GetStudentsInfo(UserListRequest) returns (StudentsInfoResponse);
+  rpc GetStudentInfo(UserRequest) returns (UserIdAndUserInfo);
+  rpc GetStudentsAllInfo(google.protobuf.Empty) returns (StudentsInfoResponse);
+}
+
+enum Authority {
+  STUDENT = 0;
+  TEACHER = 1;
+}
+
+message StudentsInfoResponse {
+  repeated UserIdAndUserInfo students_info = 1;
+}
+
+message UserIdAndUserInfo {
+  string user_id = 1;
+  UserInfo user_info = 2;
+}
+
+message TeacherInfo {
+  string teacher_id = 1;
+}
+
+message UserInfo {
+  string name = 1;
+  string email = 2;
+  Authority authority = 3;
+  int32 grade = 4;
+  int32 class_num = 5;
+  int32 num = 6;
+  int32 total_volunteer_time = 7;
+  TeacherInfo teacher_info = 8;
+}

--- a/finda-auth/src/main/proto/teacher.proto
+++ b/finda-auth/src/main/proto/teacher.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package auth;
+
+import "auth.proto";
+import "google/protobuf/empty.proto";
+import "student.proto";
+
+option java_package = "finda.findaauth.adapter.in.grpc";
+option java_multiple_files = true;
+
+service TeacherService {
+  rpc GetTeachersInfo(UserListRequest) returns (TeachersInfoResponse);
+  rpc GetTeacherInfo(UserRequest) returns (UserIdAndUserInfo);
+  rpc GetTeachersAllInfo(google.protobuf.Empty) returns (TeachersInfoResponse);
+}
+
+message TeachersInfoResponse {
+  repeated UserIdAndUserInfo teachers_info = 1;
+}

--- a/finda-security-common/src/main/kotlin/finda/error/ErrorCode.kt
+++ b/finda-security-common/src/main/kotlin/finda/error/ErrorCode.kt
@@ -17,7 +17,10 @@ enum class ErrorCode(
     PASSPORT_ISSUED_IN_FUTURE(401, "Passport Issued In Future", 6),
     PASSPORT_EXPIRED(401, "Passport Expired", 7),
 
-    FORBIDDEN(403, "Can Not Access", 1);
+    FORBIDDEN(403, "Can Not Access", 1),
+
+    USER_NOT_FOUND(404, "User not found", 1),
+    TEACHER_NOT_FOUND(404, "Teacher not found", 2);
 
     override fun status(): Int = status
     override fun message(): String = message

--- a/finda-security-common/src/main/kotlin/finda/error/ErrorCode.kt
+++ b/finda-security-common/src/main/kotlin/finda/error/ErrorCode.kt
@@ -20,7 +20,8 @@ enum class ErrorCode(
     FORBIDDEN(403, "Can Not Access", 1),
 
     USER_NOT_FOUND(404, "User not found", 1),
-    TEACHER_NOT_FOUND(404, "Teacher not found", 2);
+    TEACHER_NOT_FOUND(404, "Teacher not found", 2),
+    STUDENT_NOT_FOUND(404, "Student not found", 3),;
 
     override fun status(): Int = status
     override fun message(): String = message


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> issue에서 작성했던 api에 유저 전체 조회, 선생님 전체 조회를 추가하였습니다
---
### 👩‍💻 작업한 내용을 설명해주세요
> 학생과 선생님의 user_id를 사용하여 조회하는 gRPC api를 7개 추가하였습니다.
---
### 📸 결과물을 캡쳐해주세요
> <img width="907" height="512" alt="image" src="https://github.com/user-attachments/assets/f40fe060-2ec1-472c-80d1-bcdc4ce4f30f" />


---
### 🔗 관련 이슈 번호를 첨부하여주세요
> #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 학생·교사용 gRPC 서비스와 관련 RPC 및 프로토콜 메시지 추가
  * 사용자별 장치 응답 및 다중 사용자 정보 메시지 추가
  * 전체 및 다중 사용자 조회를 지원하는 학생·교사 조회 API(도메인·퍼시스턴스·포트 확장) 추가
  * 사용자/교사/학생 미발견을 나타내는 명시적 예외 및 에러 코드 추가

* **잡무(Chore)**
  * 개발용 무시 패턴(.gitignore) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->