### PR TITLE
merge(#37) 학년/반 필터링 학생 목록 조회 기능 구현

### DIFF
--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/StudentWebAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/StudentWebAdapter.kt
@@ -6,6 +6,8 @@ import finda.findaauth.adapter.`in`.student.dto.request.SendEmailVerificationWeb
 import finda.findaauth.adapter.`in`.student.dto.request.StudentLoginWebRequest
 import finda.findaauth.adapter.`in`.student.dto.request.StudentSignupWebRequest
 import finda.findaauth.adapter.`in`.student.dto.request.VerifyEmailCodeWebRequest
+import finda.findaauth.adapter.`in`.student.dto.response.GetStudentsResponse
+import finda.findaauth.application.port.`in`.student.GetStudentsUseCase
 import finda.findaauth.application.port.`in`.student.SendEmailVerificationUseCase
 import finda.findaauth.application.port.`in`.student.StudentLoginUseCase
 import finda.findaauth.application.port.`in`.student.StudentSignupUseCase
@@ -15,9 +17,11 @@ import finda.findaauth.application.port.`in`.student.dto.request.StudentLoginCom
 import finda.findaauth.application.port.`in`.student.dto.request.StudentSignupCommand
 import finda.findaauth.application.port.`in`.student.dto.request.VerifyEmailCodeCommand
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -26,7 +30,8 @@ class StudentWebAdapter(
     private val sendEmailVerificationUseCase: SendEmailVerificationUseCase,
     private val verifyEmailCodeUseCase: VerifyEmailCodeUseCase,
     private val studentSignupUseCase: StudentSignupUseCase,
-    private val studentLoginUseCase: StudentLoginUseCase
+    private val studentLoginUseCase: StudentLoginUseCase,
+    private val getStudentsUseCase: GetStudentsUseCase
 ) {
 
     @PostMapping("/send-verification")
@@ -83,6 +88,19 @@ class StudentWebAdapter(
                     accountId = request.accountId,
                     password = request.password
                 )
+            )
+        )
+    }
+
+    @GetMapping
+    fun getStudents(
+        @RequestParam(required = false) grade: Int?,
+        @RequestParam(required = false) classNum: Int?
+    ): GetStudentsResponse {
+        return GetStudentsResponse.from(
+            getStudentsUseCase.execute(
+                grade,
+                classNum
             )
         )
     }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/GetStudentsResponse.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/GetStudentsResponse.kt
@@ -1,0 +1,23 @@
+package finda.findaauth.adapter.`in`.student.dto.response
+
+import finda.findaauth.application.port.`in`.student.dto.response.GetStudentsResult
+
+data class GetStudentsResponse(
+    val students: List<StudentResponse>
+) {
+    data class StudentResponse(
+        val gcn: Int,
+        val name: String
+    )
+
+    companion object {
+        fun from(result: GetStudentsResult) = GetStudentsResponse(
+            students = result.students.map {
+                StudentResponse(
+                    gcn = it.gcn,
+                    name = it.name
+                )
+            }
+        )
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/GetStudentsResponse.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/GetStudentsResponse.kt
@@ -1,11 +1,13 @@
 package finda.findaauth.adapter.`in`.student.dto.response
 
 import finda.findaauth.application.port.`in`.student.dto.response.GetStudentsResult
+import java.util.UUID
 
 data class GetStudentsResponse(
     val students: List<StudentResponse>
 ) {
     data class StudentResponse(
+        val id: UUID,
         val gcn: Int,
         val name: String
     )
@@ -14,6 +16,7 @@ data class GetStudentsResponse(
         fun from(result: GetStudentsResult) = GetStudentsResponse(
             students = result.students.map {
                 StudentResponse(
+                    id = it.id,
                     gcn = it.gcn,
                     name = it.name
                 )

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
@@ -47,4 +47,15 @@ class StudentPersistenceAdapter(
     override fun findAll(): List<Student> {
         return studentRepository.findAll().map(studentMapper::toDomain).toList()
     }
+
+    override fun findAllByGradeAndClassNum(grade: Int?, classNum: Int?): List<Student> {
+        return when {
+            grade != null && classNum != null ->
+                studentRepository.findAllByGradeAndClassNum(grade, classNum)
+            grade != null ->
+                studentRepository.findAllByGrade(grade)
+            else ->
+                studentRepository.findAll()
+        }.map(studentMapper::toDomain)
+    }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/mapper/StudentMapper.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/mapper/StudentMapper.kt
@@ -15,6 +15,7 @@ class StudentMapper {
             grade = entity.grade,
             classNum = entity.classNum,
             num = entity.num,
+            name = entity.user.name,
             totalVolunteerTime = entity.totalVolunteerTime
         )
 

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/repository/StudentRepository.kt
@@ -16,4 +16,8 @@ interface StudentRepository : CrudRepository<StudentJpaEntity, UUID> {
     fun existsByGradeAndClassNumAndNum(grade: Int, classNum: Int, num: Int): Boolean
 
     fun findByUser(user: UserJpaEntity): Optional<StudentJpaEntity>
+
+    fun findAllByGrade(grade: Int): List<StudentJpaEntity>
+
+    fun findAllByGradeAndClassNum(grade: Int, classNum: Int): List<StudentJpaEntity>
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/GetStudentsUseCase.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/GetStudentsUseCase.kt
@@ -1,0 +1,7 @@
+package finda.findaauth.application.port.`in`.student
+
+import finda.findaauth.application.port.`in`.student.dto.response.GetStudentsResult
+
+interface GetStudentsUseCase {
+    fun execute(grade: Int?, classNum: Int?): GetStudentsResult
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/GetStudentsResult.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/GetStudentsResult.kt
@@ -1,0 +1,26 @@
+package finda.findaauth.application.port.`in`.student.dto.response
+
+import finda.findaauth.domain.student.model.Student
+import java.util.UUID
+
+data class GetStudentsResult(
+    val students: List<StudentResult>
+) {
+    data class StudentResult(
+        val userId: UUID,
+        val gcn: Int,
+        val name: String
+    )
+
+    companion object {
+        fun from(students: List<Student>) = GetStudentsResult(
+            students = students.map { student ->
+                StudentResult(
+                    userId = student.userId,
+                    gcn = student.grade * 1000 + student.classNum * 100 + student.num,
+                    name = student.name
+                )
+            }
+        )
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/GetStudentsResult.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/GetStudentsResult.kt
@@ -7,7 +7,7 @@ data class GetStudentsResult(
     val students: List<StudentResult>
 ) {
     data class StudentResult(
-        val userId: UUID,
+        val id: UUID,
         val gcn: Int,
         val name: String
     )
@@ -16,7 +16,7 @@ data class GetStudentsResult(
         fun from(students: List<Student>) = GetStudentsResult(
             students = students.map { student ->
                 StudentResult(
-                    userId = student.userId,
+                    id = student.userId,
                     gcn = student.grade * 1000 + student.classNum * 100 + student.num,
                     name = student.name
                 )

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
@@ -13,4 +13,6 @@ interface StudentQueryPort {
     fun findAllByUserIds(userIds: List<UUID>): List<Student?>
 
     fun findAll(): List<Student>
+
+    fun findAllByGradeAndClassNum(grade: Int?, classNum: Int?): List<Student>
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/GetStudentsService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/GetStudentsService.kt
@@ -1,0 +1,17 @@
+package finda.findaauth.application.service.student
+
+import finda.findaauth.application.port.`in`.student.GetStudentsUseCase
+import finda.findaauth.application.port.`in`.student.dto.response.GetStudentsResult
+import finda.findaauth.application.port.out.student.StudentQueryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetStudentsService(
+    private val studentQueryPort: StudentQueryPort
+) : GetStudentsUseCase {
+
+    override fun execute(grade: Int?, classNum: Int?): GetStudentsResult {
+        val students = studentQueryPort.findAllByGradeAndClassNum(grade, classNum)
+        return GetStudentsResult.from(students)
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/StudentLoginService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/StudentLoginService.kt
@@ -32,7 +32,7 @@ class StudentLoginService(
             throw InvalidCredentialsException
         }
 
-        if (!studentQueryPort.existsByUserId(user.id!!)) {
+        if (!studentQueryPort.existsByUserId(user.id)) {
             throw InvalidCredentialsException
         }
 

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/StudentSignupService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/StudentSignupService.kt
@@ -49,7 +49,8 @@ class StudentSignupService(
             userId = user.id,
             grade = studentNumber.grade,
             classNum = studentNumber.classNum,
-            num = studentNumber.num
+            num = studentNumber.num,
+            name = name
         )
 
         studentCommandPort.save(student)

--- a/finda-auth/src/main/kotlin/finda/findaauth/domain/student/model/Student.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/domain/student/model/Student.kt
@@ -7,5 +7,6 @@ data class Student(
     val grade: Int,
     val classNum: Int,
     val num: Int,
+    val name: String,
     val totalVolunteerTime: Int = 0
 )

--- a/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
@@ -47,7 +47,7 @@ class SecurityConfig(
                     "/students/verify-email",
                     "/email/**"
                 ).permitAll()
-                it.requestMatchers(HttpMethod.GET,"/students").hasAuthority("STUDENT")
+                it.requestMatchers(HttpMethod.GET,"/students").hasAuthority("TEACHER")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(PassportFilter(passportProperties, userQueryPort), UsernamePasswordAuthenticationFilter::class.java)

--- a/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
@@ -47,7 +47,7 @@ class SecurityConfig(
                     "/students/verify-email",
                     "/email/**"
                 ).permitAll()
-                it.requestMatchers(HttpMethod.GET,"/student").hasAuthority("STUDENT")
+                it.requestMatchers(HttpMethod.GET,"/students").hasAuthority("STUDENT")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(PassportFilter(passportProperties, userQueryPort), UsernamePasswordAuthenticationFilter::class.java)

--- a/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
@@ -6,6 +6,7 @@ import finda.findaauth.global.error.filter.ExceptionFilter
 import finda.findaauth.global.security.passport.filter.PassportFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -46,6 +47,7 @@ class SecurityConfig(
                     "/students/verify-email",
                     "/email/**"
                 ).permitAll()
+                it.requestMatchers(HttpMethod.GET,"/student").hasRole("STUDENT")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(PassportFilter(passportProperties, userQueryPort), UsernamePasswordAuthenticationFilter::class.java)

--- a/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/global/config/SecurityConfig.kt
@@ -47,7 +47,7 @@ class SecurityConfig(
                     "/students/verify-email",
                     "/email/**"
                 ).permitAll()
-                it.requestMatchers(HttpMethod.GET,"/student").hasRole("STUDENT")
+                it.requestMatchers(HttpMethod.GET,"/student").hasAuthority("STUDENT")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(PassportFilter(passportProperties, userQueryPort), UsernamePasswordAuthenticationFilter::class.java)


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> 리뷰 시 참고할 점이 있다면 작성해주세요.
* grade, classNum 모두 null이면 전교생 반환, 하나만 넣으면 해당 학년 전체 반환
---
### 👩‍💻 작업한 내용을 설명해주세요
> 이번 작업에서 수행한 내용을 간단히 설명해주세요.
- grade, classNum을 optional RequestParam으로 받아 필터링
- 학번(gcn)은 grade * 1000 + classNum * 100 + num 으로 계산하여 반환
- Student 도메인 모델에 name 필드 추가

---
### 📸 결과물을 캡쳐해주세요
> 결과 화면을 첨부해주세요.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.
#37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 학년/반 선택적 필터로 학생 목록을 조회하는 공개 API가 추가되었습니다.

* **버그 수정**
  * 학생 로그인 흐름의 널 처리 안정성이 개선되었습니다.

* **개선사항**
  * 학생 데이터에 이름 필드가 일관되게 포함되어 조회·등록 시 표시됩니다.
  * 학생 조회 엔드포인트 접근 권한이 TEACHER로 명시되어 보안이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->