### PR TITLE
merge(#47) mypage api

### DIFF
--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/StudentWebAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/StudentWebAdapter.kt
@@ -7,6 +7,8 @@ import finda.findaauth.adapter.`in`.student.dto.request.StudentLoginWebRequest
 import finda.findaauth.adapter.`in`.student.dto.request.StudentSignupWebRequest
 import finda.findaauth.adapter.`in`.student.dto.request.VerifyEmailCodeWebRequest
 import finda.findaauth.adapter.`in`.student.dto.response.GetStudentsResponse
+import finda.findaauth.adapter.`in`.student.dto.response.StudentProfileResponse
+import finda.findaauth.application.port.`in`.student.GetStudentProfileUseCase
 import finda.findaauth.application.port.`in`.student.GetStudentsUseCase
 import finda.findaauth.application.port.`in`.student.SendEmailVerificationUseCase
 import finda.findaauth.application.port.`in`.student.StudentLoginUseCase
@@ -16,6 +18,7 @@ import finda.findaauth.application.port.`in`.student.dto.request.SendEmailVerifi
 import finda.findaauth.application.port.`in`.student.dto.request.StudentLoginCommand
 import finda.findaauth.application.port.`in`.student.dto.request.StudentSignupCommand
 import finda.findaauth.application.port.`in`.student.dto.request.VerifyEmailCodeCommand
+import finda.findaauth.application.service.user.UserFacade
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -31,7 +34,9 @@ class StudentWebAdapter(
     private val verifyEmailCodeUseCase: VerifyEmailCodeUseCase,
     private val studentSignupUseCase: StudentSignupUseCase,
     private val studentLoginUseCase: StudentLoginUseCase,
-    private val getStudentsUseCase: GetStudentsUseCase
+    private val getStudentsUseCase: GetStudentsUseCase,
+    private val getStudentProfileUseCase: GetStudentProfileUseCase,
+    private val userFacade: UserFacade
 ) {
 
     @PostMapping("/send-verification")
@@ -103,5 +108,11 @@ class StudentWebAdapter(
                 classNum
             )
         )
+    }
+
+    @GetMapping("/me")
+    fun getMyProfile(): StudentProfileResponse {
+        val userId = userFacade.getCurrentUserId()
+        return StudentProfileResponse.from(getStudentProfileUseCase.getProfile(userId))
     }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/StudentProfileResponse.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/student/dto/response/StudentProfileResponse.kt
@@ -1,0 +1,15 @@
+package finda.findaauth.adapter.`in`.student.dto.response
+
+import finda.findaauth.application.port.`in`.student.dto.response.StudentProfileResult
+
+data class StudentProfileResponse(
+    val name: String,
+    val topActivities: List<String>
+) {
+    companion object {
+        fun from(result: StudentProfileResult) = StudentProfileResponse(
+            name = result.name,
+            topActivities = result.topActivities
+        )
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/teacher/TeacherWebAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/teacher/TeacherWebAdapter.kt
@@ -8,6 +8,8 @@ import finda.findaauth.adapter.`in`.teacher.dto.request.TeacherSignupWebRequest
 import finda.findaauth.adapter.`in`.teacher.dto.request.VerifyEmailCodeWebRequest
 import finda.findaauth.adapter.`in`.teacher.dto.request.VerifySignupWebRequest
 import finda.findaauth.adapter.`in`.teacher.dto.response.PreAuthTokenWebResponse
+import finda.findaauth.adapter.`in`.teacher.dto.response.TeacherProfileResponse
+import finda.findaauth.application.port.`in`.teacher.GetTeacherProfileUseCase
 import finda.findaauth.application.port.`in`.teacher.SendEmailVerificationUseCase
 import finda.findaauth.application.port.`in`.teacher.TeacherLoginUseCase
 import finda.findaauth.application.port.`in`.teacher.TeacherSignupUseCase
@@ -18,7 +20,9 @@ import finda.findaauth.application.port.`in`.teacher.dto.request.TeacherLoginCom
 import finda.findaauth.application.port.`in`.teacher.dto.request.TeacherSignupCommand
 import finda.findaauth.application.port.`in`.teacher.dto.request.VerifyEmailCodeCommand
 import finda.findaauth.application.port.`in`.teacher.dto.request.VerifySignupCommand
+import finda.findaauth.application.service.user.UserFacade
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -32,7 +36,9 @@ class TeacherWebAdapter(
     private val sendEmailVerificationUseCase: SendEmailVerificationUseCase,
     private val verifyEmailCodeUseCase: VerifyEmailCodeUseCase,
     private val teacherSignupUseCase: TeacherSignupUseCase,
-    private val teacherLoginUseCase: TeacherLoginUseCase
+    private val teacherLoginUseCase: TeacherLoginUseCase,
+    private val getTeacherProfileUseCase: GetTeacherProfileUseCase,
+    private val userFacade: UserFacade
 ) {
 
     @PostMapping("/verify")
@@ -111,5 +117,11 @@ class TeacherWebAdapter(
                 )
             )
         )
+    }
+
+    @GetMapping("/me")
+    fun getMyProfile(): TeacherProfileResponse {
+        val userId = userFacade.getCurrentUserId()
+        return TeacherProfileResponse.from(getTeacherProfileUseCase.getProfile(userId))
     }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/teacher/dto/response/TeacherProfileResponse.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/in/teacher/dto/response/TeacherProfileResponse.kt
@@ -1,0 +1,13 @@
+package finda.findaauth.adapter.`in`.teacher.dto.response
+
+import finda.findaauth.application.port.`in`.teacher.dto.response.TeacherProfileResult
+
+data class TeacherProfileResponse(
+    val name: String
+) {
+    companion object {
+        fun from(result: TeacherProfileResult) = TeacherProfileResponse(
+            name = result.name
+        )
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/grpc/VolunteerGrpcClient.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/grpc/VolunteerGrpcClient.kt
@@ -34,7 +34,7 @@ class VolunteerGrpcClient : VolunteerGrpcPort {
         } catch (e: StatusRuntimeException) {
             when (e.status.code) {
                 Status.Code.NOT_FOUND -> {
-                    log.info("Volunteer activities not found for userId=$userId")
+                    log.info("Volunteer activities not found for userId")
                     emptyList()
                 }
                 Status.Code.DEADLINE_EXCEEDED -> {

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/grpc/VolunteerGrpcClient.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/grpc/VolunteerGrpcClient.kt
@@ -1,0 +1,51 @@
+package finda.findaauth.adapter.out.grpc
+
+import finda.findaauth.adapter.`in`.grpc.GetTopActivitiesRequest
+import finda.findaauth.adapter.`in`.grpc.VolunteerServiceGrpc
+import finda.findaauth.application.port.out.grpc.VolunteerGrpcPort
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Component
+class VolunteerGrpcClient : VolunteerGrpcPort {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GrpcClient("volunteer-service")
+    private lateinit var volunteerServiceStub: VolunteerServiceGrpc.VolunteerServiceBlockingStub
+
+    private val callTimeoutSeconds = 2L
+
+    override fun getTopActivities(userId: UUID): List<String> {
+        return try {
+            val request = GetTopActivitiesRequest.newBuilder()
+                .setUserId(userId.toString())
+                .build()
+
+            volunteerServiceStub
+                .withDeadlineAfter(callTimeoutSeconds, TimeUnit.SECONDS)
+                .getTopActivitiesByVolunteerTime(request)
+                .activityNamesList
+        } catch (e: StatusRuntimeException) {
+            when (e.status.code) {
+                Status.Code.NOT_FOUND -> {
+                    log.info("Volunteer activities not found for userId=$userId")
+                    emptyList()
+                }
+                Status.Code.DEADLINE_EXCEEDED -> {
+                    log.error("gRPC getTopActivities timeout")
+                    throw e
+                }
+                else -> {
+                    log.error("gRPC getTopActivities failed", e)
+                    throw e
+                }
+            }
+        }
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/devicetoken/entity/DeviceTokenJpaEntity.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/devicetoken/entity/DeviceTokenJpaEntity.kt
@@ -11,11 +11,12 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.util.UUID
 
 @Entity
 @Table(name = "tbl_device_token")
 class DeviceTokenJpaEntity(
-    id: java.util.UUID? = null,
+    id: UUID? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/StudentPersistenceAdapter.kt
@@ -58,4 +58,9 @@ class StudentPersistenceAdapter(
                 studentRepository.findAll()
         }.map(studentMapper::toDomain)
     }
+
+    override fun findNameByUserId(userId: UUID): String? {
+        val userEntity = userRepository.findByIdOrNull(userId) ?: return null
+        return userEntity.name
+    }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/entity/StudentJpaEntity.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/student/entity/StudentJpaEntity.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import java.util.UUID
 
 @Entity
 @Table(
@@ -22,7 +23,7 @@ import jakarta.persistence.UniqueConstraint
     ]
 )
 class StudentJpaEntity(
-    id: java.util.UUID? = null,
+    id: UUID? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true)

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
@@ -46,4 +46,9 @@ class TeacherPersistenceAdapter(
     override fun findAll(): List<Teacher> {
         return teacherRepository.findAll().map(teacherMapper::toDomain).toList()
     }
+
+    override fun findNameByUserId(userId: UUID): String? {
+        val userEntity = userRepository.findByIdOrNull(userId) ?: return null
+        return userEntity.name
+    }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/TeacherPersistenceAdapter.kt
@@ -49,6 +49,7 @@ class TeacherPersistenceAdapter(
 
     override fun findNameByUserId(userId: UUID): String? {
         val userEntity = userRepository.findByIdOrNull(userId) ?: return null
+        teacherRepository.findByUser(userEntity).orElse(null) ?: return null
         return userEntity.name
     }
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/entity/TeacherJpaEntity.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/teacher/entity/TeacherJpaEntity.kt
@@ -7,11 +7,12 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.util.UUID
 
 @Entity
 @Table(name = "tbl_teacher")
 class TeacherJpaEntity(
-    id: java.util.UUID? = null,
+    id: UUID? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true)

--- a/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/user/entity/UserJpaEntity.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/adapter/out/persistence/user/entity/UserJpaEntity.kt
@@ -8,11 +8,12 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Entity
 @Table(name = "tbl_user")
 class UserJpaEntity(
-    id: java.util.UUID? = null,
+    id: UUID? = null,
 
     @Column(name = "name", nullable = false)
     val name: String,

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/GetStudentProfileUseCase.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/GetStudentProfileUseCase.kt
@@ -1,0 +1,8 @@
+package finda.findaauth.application.port.`in`.student
+
+import finda.findaauth.application.port.`in`.student.dto.response.StudentProfileResult
+import java.util.UUID
+
+interface GetStudentProfileUseCase {
+    fun getProfile(userId: UUID): StudentProfileResult
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/StudentProfileResult.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/student/dto/response/StudentProfileResult.kt
@@ -1,0 +1,6 @@
+package finda.findaauth.application.port.`in`.student.dto.response
+
+data class StudentProfileResult(
+    val name: String,
+    val topActivities: List<String>
+)

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/teacher/GetTeacherProfileUseCase.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/teacher/GetTeacherProfileUseCase.kt
@@ -1,0 +1,8 @@
+package finda.findaauth.application.port.`in`.teacher
+
+import finda.findaauth.application.port.`in`.teacher.dto.response.TeacherProfileResult
+import java.util.UUID
+
+interface GetTeacherProfileUseCase {
+    fun getProfile(id: UUID): TeacherProfileResult
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/teacher/dto/response/TeacherProfileResult.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/in/teacher/dto/response/TeacherProfileResult.kt
@@ -1,0 +1,5 @@
+package finda.findaauth.application.port.`in`.teacher.dto.response
+
+data class TeacherProfileResult(
+    val name: String
+)

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/grpc/VolunteerGrpcPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/grpc/VolunteerGrpcPort.kt
@@ -1,0 +1,7 @@
+package finda.findaauth.application.port.out.grpc
+
+import java.util.UUID
+
+interface VolunteerGrpcPort {
+    fun getTopActivities(id: UUID): List<String>
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/student/StudentQueryPort.kt
@@ -15,4 +15,6 @@ interface StudentQueryPort {
     fun findAll(): List<Student>
 
     fun findAllByGradeAndClassNum(grade: Int?, classNum: Int?): List<Student>
+
+    fun findNameByUserId(userId: UUID): String?
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/teacher/TeacherQueryPort.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/port/out/teacher/TeacherQueryPort.kt
@@ -8,4 +8,5 @@ interface TeacherQueryPort {
     fun findTeacherByUserId(userId: UUID): Teacher?
     fun findAllByUserIds(userIds: List<UUID>): List<Teacher?>
     fun findAll(): List<Teacher>
+    fun findNameByUserId(userId: UUID): String?
 }

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/GetStudentProfileService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/student/GetStudentProfileService.kt
@@ -1,0 +1,27 @@
+package finda.findaauth.application.service.student
+
+import finda.findaauth.application.exception.student.StudentNotFoundException
+import finda.findaauth.application.port.`in`.student.GetStudentProfileUseCase
+import finda.findaauth.application.port.`in`.student.dto.response.StudentProfileResult
+import finda.findaauth.application.port.out.grpc.VolunteerGrpcPort
+import finda.findaauth.application.port.out.student.StudentQueryPort
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class GetStudentProfileService(
+    private val studentQueryPort: StudentQueryPort,
+    private val volunteerGrpcPort: VolunteerGrpcPort
+) : GetStudentProfileUseCase {
+
+    override fun getProfile(userId: UUID): StudentProfileResult {
+        val name = studentQueryPort.findNameByUserId(userId)
+            ?: throw StudentNotFoundException
+        val topActivities = volunteerGrpcPort.getTopActivities(userId)
+
+        return StudentProfileResult(
+            name = name,
+            topActivities = topActivities
+        )
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/teacher/GetTeacherProfileService.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/teacher/GetTeacherProfileService.kt
@@ -1,0 +1,21 @@
+package finda.findaauth.application.service.teacher
+
+import finda.findaauth.application.exception.teacher.TeacherNotFoundException
+import finda.findaauth.application.port.`in`.teacher.GetTeacherProfileUseCase
+import finda.findaauth.application.port.`in`.teacher.dto.response.TeacherProfileResult
+import finda.findaauth.application.port.out.teacher.TeacherQueryPort
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class GetTeacherProfileService(
+    private val teacherQueryPort: TeacherQueryPort
+) : GetTeacherProfileUseCase {
+
+    override fun getProfile(id: UUID): TeacherProfileResult {
+        val name = teacherQueryPort.findNameByUserId(id)
+            ?: throw TeacherNotFoundException
+
+        return TeacherProfileResult(name = name)
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
@@ -1,5 +1,6 @@
 package finda.findaauth.application.service.user
 
+import finda.findaauth.global.security.principal.CustomUserDetails
 import finda.security.passport.model.Passport
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.security.core.context.SecurityContextHolder
@@ -8,15 +9,15 @@ import java.util.UUID
 
 @Component
 class UserFacade {
-    fun getCurrentPassport(): Passport {
+    fun getCurrentUserId(): UUID {
         val authentication = SecurityContextHolder.getContext().authentication
             ?: throw AuthenticationCredentialsNotFoundException("인증 정보가 존재하지 않습니다")
 
-        return authentication.principal as? Passport
-            ?: throw AuthenticationCredentialsNotFoundException("유효하지 않은 인증 principal 타입입니다: ${authentication.principal::class.simpleName}")
-    }
-
-    fun getCurrentUserId(): UUID {
-        return getCurrentPassport().userId
+        return when (val principal = authentication.principal) {
+            is Passport -> principal.userId
+            is CustomUserDetails -> UUID.fromString(principal.username)
+            else -> throw AuthenticationCredentialsNotFoundException("유효하지 않은 인증 principal 타입입니다: ${principal::class.simpleName}")
+        }
     }
 }
+

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
@@ -20,4 +20,3 @@ class UserFacade {
         }
     }
 }
-

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
@@ -1,0 +1,22 @@
+package finda.findaauth.application.service.user
+
+import finda.security.passport.model.Passport
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UserFacade {
+    fun getCurrentPassport(): Passport {
+        val authentication = SecurityContextHolder.getContext().authentication
+            ?: throw AuthenticationCredentialsNotFoundException("인증 정보가 존재하지 않습니다")
+
+        return authentication.principal as? Passport
+            ?: throw AuthenticationCredentialsNotFoundException("유효하지 않은 인증 principal 타입입니다: ${authentication.principal::class.simpleName}")
+    }
+
+    fun getCurrentUserId(): UUID {
+        return getCurrentPassport().userId
+    }
+}

--- a/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
+++ b/finda-auth/src/main/kotlin/finda/findaauth/application/service/user/UserFacade.kt
@@ -15,7 +15,7 @@ class UserFacade {
 
         return when (val principal = authentication.principal) {
             is Passport -> principal.userId
-            is CustomUserDetails -> UUID.fromString(principal.username)
+            is CustomUserDetails -> principal.user.id
             else -> throw AuthenticationCredentialsNotFoundException("유효하지 않은 인증 principal 타입입니다: ${principal::class.simpleName}")
         }
     }

--- a/finda-auth/src/main/proto/volunteer.proto
+++ b/finda-auth/src/main/proto/volunteer.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package volunteer;
+
+option java_package = "finda.findaauth.adapter.in.grpc";
+option java_multiple_files = true;
+
+service VolunteerService {
+  rpc GetTopActivitiesByVolunteerTime(GetTopActivitiesRequest) returns (GetTopActivitiesResponse);
+}
+
+message GetTopActivitiesRequest {
+  string user_id = 1;
+}
+
+message GetTopActivitiesResponse {
+  repeated string activity_names = 1;
+}

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/in/grpc/VolunteerGrpcService.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/in/grpc/VolunteerGrpcService.kt
@@ -34,6 +34,29 @@ class VolunteerGrpcService(
             .build()
     }
 
+    override fun getTopActivitiesByVolunteerTime(
+        request: GetTopActivitiesRequest,
+        responseObserver: StreamObserver<GetTopActivitiesResponse>
+    ) = handleGrpc(responseObserver) {
+        val activities = getVolunteerService.getTopActivitiesByVolunteerTime(
+            parseUUID(request.userId)
+        )
+
+        GetTopActivitiesResponse.newBuilder()
+            .addAllActivityNames(activities)
+            .build()
+    }
+
+    private fun parseUUID(value: String): UUID =
+        try {
+            UUID.fromString(value)
+        } catch (e: IllegalArgumentException) {
+            throw Status.INVALID_ARGUMENT
+                .withDescription("Invalid UUID format")
+                .withCause(e)
+                .asRuntimeException()
+        }
+
     private fun <T> handleGrpc(
         observer: StreamObserver<T>,
         block: () -> T
@@ -51,18 +74,5 @@ class VolunteerGrpcService(
                     .asRuntimeException()
             )
         }
-    }
-
-    override fun getTopActivitiesByVolunteerTime(
-        request: GetTopActivitiesRequest,
-        responseObserver: StreamObserver<GetTopActivitiesResponse>
-    ) = handleGrpc(responseObserver) {
-        val activities = getVolunteerService.getTopActivitiesByVolunteerTime(
-            UUID.fromString(request.userId)
-        )
-
-        GetTopActivitiesResponse.newBuilder()
-            .addAllActivityNames(activities)
-            .build()
     }
 }

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/in/grpc/VolunteerGrpcService.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/in/grpc/VolunteerGrpcService.kt
@@ -1,6 +1,8 @@
 package finda.findavolunteer.adapter.`in`.grpc
 
 import com.google.protobuf.Empty
+import finda.findavolunteer.adapter.out.grpc.GetTopActivitiesRequest
+import finda.findavolunteer.adapter.out.grpc.GetTopActivitiesResponse
 import finda.findavolunteer.adapter.out.grpc.RemindTimeItem
 import finda.findavolunteer.adapter.out.grpc.RemindTimeListResponse
 import finda.findavolunteer.adapter.out.grpc.VolunteerServiceGrpc
@@ -9,6 +11,7 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import net.devh.boot.grpc.server.service.GrpcService
+import java.util.UUID
 
 @GrpcService
 class VolunteerGrpcService(
@@ -48,5 +51,18 @@ class VolunteerGrpcService(
                     .asRuntimeException()
             )
         }
+    }
+
+    override fun getTopActivitiesByVolunteerTime(
+        request: GetTopActivitiesRequest,
+        responseObserver: StreamObserver<GetTopActivitiesResponse>
+    ) = handleGrpc(responseObserver) {
+        val activities = getVolunteerService.getTopActivitiesByVolunteerTime(
+            UUID.fromString(request.userId)
+        )
+
+        GetTopActivitiesResponse.newBuilder()
+            .addAllActivityNames(activities)
+            .build()
     }
 }

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/VolunteerPersistenceAdapter.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/VolunteerPersistenceAdapter.kt
@@ -62,4 +62,8 @@ class VolunteerPersistenceAdapter(
         return volunteerRepository.findAllByRemindTimeIsNotNull()
             .map { volunteerMapper.toDomain(it) }
     }
+
+    override fun findTopActivitiesByUserId(userId: UUID): List<String> {
+        return volunteerRepository.findTop3TitlesByUserId(userId)
+    }
 }

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/repository/VolunteerRepository.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/repository/VolunteerRepository.kt
@@ -12,6 +12,7 @@ interface VolunteerRepository : CrudRepository<VolunteerJpaEntity, UUID> {
     fun findAllByUserId(userId: UUID): List<VolunteerJpaEntity>
     fun findAllByRemindTimeIsNotNull(): List<VolunteerJpaEntity>
 
+    // TODO: JPQL은 LIMIT을 공식 지원하지 않음. QueryDSL 전환 시 수정 필요
     @Query(
         """
     SELECT v.title

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/repository/VolunteerRepository.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/adapter/out/persistence/volunteer/repository/VolunteerRepository.kt
@@ -1,7 +1,9 @@
 package finda.findavolunteer.adapter.out.persistence.volunteer.repository
 
 import finda.findavolunteer.adapter.out.persistence.volunteer.entity.VolunteerJpaEntity
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -9,4 +11,18 @@ import java.util.UUID
 interface VolunteerRepository : CrudRepository<VolunteerJpaEntity, UUID> {
     fun findAllByUserId(userId: UUID): List<VolunteerJpaEntity>
     fun findAllByRemindTimeIsNotNull(): List<VolunteerJpaEntity>
+
+    @Query(
+        """
+    SELECT v.title
+    FROM VolunteerJpaEntity v
+    JOIN StudentParticipationJpaEntity sp ON sp.volunteer = v
+    WHERE sp.userId = :userId
+    AND sp.status = 'PARTICIPATED'
+    GROUP BY v.id, v.title
+    ORDER BY SUM(v.unitVolunteerHours) DESC
+    LIMIT 3
+"""
+    )
+    fun findTop3TitlesByUserId(@Param("userId") userId: UUID): List<String>
 }

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/application/port/out/volunteer/VolunteerQueryPort.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/application/port/out/volunteer/VolunteerQueryPort.kt
@@ -8,4 +8,5 @@ interface VolunteerQueryPort {
     fun findById(id: UUID): Volunteer?
     fun findByIdOrThrow(id: UUID): Volunteer
     fun findAllWithRemindTime(): List<Volunteer>
+    fun findTopActivitiesByUserId(userId: UUID): List<String>
 }

--- a/finda-volunteer/src/main/kotlin/finda/findavolunteer/application/service/volunteer/GetVolunteerService.kt
+++ b/finda-volunteer/src/main/kotlin/finda/findavolunteer/application/service/volunteer/GetVolunteerService.kt
@@ -3,6 +3,7 @@ package finda.findavolunteer.application.service.volunteer
 import finda.findavolunteer.application.port.out.volunteer.VolunteerQueryPort
 import finda.findavolunteer.domain.volunteer.model.Volunteer
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class GetVolunteerService(
@@ -10,5 +11,9 @@ class GetVolunteerService(
 ) {
     fun getAllRemindTimes(): List<Volunteer> {
         return volunteerQueryPort.findAllWithRemindTime()
+    }
+
+    fun getTopActivitiesByVolunteerTime(userId: UUID): List<String> {
+        return volunteerQueryPort.findTopActivitiesByUserId(userId)
     }
 }

--- a/finda-volunteer/src/main/proto/volunteer.proto
+++ b/finda-volunteer/src/main/proto/volunteer.proto
@@ -9,6 +9,7 @@ import "google/protobuf/empty.proto";
 
 service VolunteerService {
   rpc GetAllRemindTimes (google.protobuf.Empty) returns (RemindTimeListResponse);
+  rpc GetTopActivitiesByVolunteerTime (GetTopActivitiesRequest) returns (GetTopActivitiesResponse);
 }
 
 message RemindTimeListResponse {
@@ -18,4 +19,12 @@ message RemindTimeListResponse {
 message RemindTimeItem {
   string volunteer_id = 1;
   string remind_time = 2;
+}
+
+message GetTopActivitiesRequest {
+  string user_id = 1;
+}
+
+message GetTopActivitiesResponse {
+  repeated string activity_names = 1;
 }


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> 리뷰 시 참고할 점이 있다면 작성해주세요.
- auth 모듈의 PassportFilter가 CustomUserDetails를 principal로 설정하는 구조를 유지하기 위해
  UserFacade에서 CustomUserDetails와 Passport 둘 다 처리하도록 수정했습니다.
- volunteer 모듈과 gRPC 통신을 통해 봉사시간 기준 top3를 가져옵니다.

---
### 👩‍💻 작업한 내용을 설명해주세요
> 이번 작업에서 수행한 내용을 간단히 설명해주세요.
- 학생/선생님 마이페이지 프로필 조회 API 구현
  - `GET /students/me` : 이름 + 봉사시간 기준 top3 봉사활동 반환
  - `GET /teachers/me` : 이름 반환
- volunteer 모듈과 gRPC 통신으로 학생의 누적 봉사시간 기준 top3 봉사활동 조회
- UserFacade에서 CustomUserDetails principal 타입 처리 추가

---
### 📸 결과물을 캡쳐해주세요
> 결과 화면을 첨부해주세요.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.
#47 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학생이 본인 프로필 조회 가능 — 이름과 상위 봉사활동 목록(최대 3개) 표시
  * 교사가 본인 프로필 조회 가능 — 이름 표시
  * 백엔드에서 사용자별 상위 봉사활동을 집계해 학생 프로필에 통합 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->