### PR TITLE
merge(#52) CI 환경에서 gradle daemon 비활성화 및 메모리 최적화

### DIFF
--- a/finda-auth/Dockerfile
+++ b/finda-auth/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-volunteer:bootJar -x test --no-daemon
+RUN gradle :finda-auth:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-auth/Dockerfile
+++ b/finda-auth/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-auth:bootJar -x test
+RUN gradle :finda-volunteer:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-batch/Dockerfile
+++ b/finda-batch/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-batch:bootJar -x test
+RUN gradle :finda-volunteer:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-batch/Dockerfile
+++ b/finda-batch/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-volunteer:bootJar -x test --no-daemon
+RUN gradle :finda-batch:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-gateway/Dockerfile
+++ b/finda-gateway/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-gateway:bootJar -x test
+RUN gradle :finda-volunteer:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-gateway/Dockerfile
+++ b/finda-gateway/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-volunteer:bootJar -x test --no-daemon
+RUN gradle :finda-gateway:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-notification/Dockerfile
+++ b/finda-notification/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-volunteer:bootJar -x test --no-daemon
+RUN gradle :finda-notification:bootJar -x test --no-daemon
  
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-notification/Dockerfile
+++ b/finda-notification/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-notification:bootJar -x test
+RUN gradle :finda-volunteer:bootJar -x test --no-daemon
  
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/finda-volunteer/Dockerfile
+++ b/finda-volunteer/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle :finda-volunteer:bootJar -x test
+RUN gradle :finda-volunteer:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx512m -Xms256m
+org.gradle.daemon=false


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> 리뷰 시 참고할 점이 있다면 작성해주세요.
* CI 환경에서 Docker 기반 Gradle 빌드 시 메모리 부족으로 인해 빌드가 중단되는 문제가 발생했습니다. (EOF, graceful_stop 에러 발생)
* 해당 문제 해결을 위해 Gradle daemon을 비활성화하고 메모리 사용량을 제한했습니다.

---
### 👩‍💻 작업한 내용을 설명해주세요
> 이번 작업에서 수행한 내용을 간단히 설명해주세요.

**gradle.properties 추가**
* Gradle JVM 메모리 제한 (-Xmx512m -Xms256m)
* Gradle daemon 비활성화 (org.gradle.daemon=false)

**각 서비스 Dockerfile에서 Gradle 빌드 시 --no-daemon 옵션 추가**

이를 통해 CI 환경에서의 빌드 안정성을 개선했습니다.

---
### 📸 결과물을 캡쳐해주세요
> 결과 화면을 첨부해주세요.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.
#52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 빌드 구성을 업데이트하여 빌드 성능을 최적화했습니다.
  * Gradle 데몬 실행 방식을 조정하고 JVM 메모리 할당 설정을 추가했습니다.
  * 전반적인 빌드 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->