### PR TITLE
merge(#62) fix liquibase sqlcheck precondition syntax error

### DIFF
--- a/finda-auth/src/main/resources/db/changelog-auth/data/000-create-initial-tables.sql
+++ b/finda-auth/src/main/resources/db/changelog-auth/data/000-create-initial-tables.sql
@@ -3,10 +3,7 @@
 --changeset finda-auth:000-create-auth-tables
 
 --preconditions onFail:MARK_RAN
---precondition-sql-check expectedResult:0
-SELECT COUNT(*) FROM information_schema.tables
-WHERE table_name = 'tbl_user'
-  AND table_schema = DATABASE();
+--precondition-sql-check expectedResult 0 SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'tbl_user' AND table_schema = DATABASE()
 
 CREATE TABLE tbl_user
 (

--- a/finda-notification/src/main/resources/db/changelog-notification/data/000-create-notification-tables.sql
+++ b/finda-notification/src/main/resources/db/changelog-notification/data/000-create-notification-tables.sql
@@ -3,10 +3,7 @@
 --changeset finda-notification:000-create-notification-tables
 
 --preconditions onFail:MARK_RAN
---precondition-sql-check expectedResult:0
-SELECT COUNT(*) FROM information_schema.tables
-WHERE table_name = 'tbl_notice'
-  AND table_schema = DATABASE();
+--precondition-sql-check expectedResult 0 SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'tbl_notice' AND table_schema = DATABASE()
 
 CREATE TABLE tbl_notice
 (


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> 리뷰 시 참고할 점이 있다면 작성해주세요.

---
### 👩‍💻 작업한 내용을 설명해주세요
> 이번 작업에서 수행한 내용을 간단히 설명해주세요.
* finda-auth, finda-notification 모듈의 Liquibase changelog 파일에서 잘못된 SqlCheck precondition 문법 수정
---
### 📸 결과물을 캡쳐해주세요
> 결과 화면을 첨부해주세요.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.
#62 