### PR TITLE
merge(#66) Firebase 서비스 계정 키를 classpath JSON 파일에서 환경변수 주입 방식으로 변경

### DIFF
--- a/finda-notification/src/main/kotlin/finda/findanotification/global/config/FirebaseConfig.kt
+++ b/finda-notification/src/main/kotlin/finda/findanotification/global/config/FirebaseConfig.kt
@@ -1,11 +1,12 @@
 package finda.findanotification.global.config
 
+import com.google.api.client.util.Value
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import jakarta.annotation.PostConstruct
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ClassPathResource
+import java.io.ByteArrayInputStream
 
 /**
  * 앱 시작 시 서비스 계정 JSON으로 Firebase에 로그인하는 코드
@@ -13,10 +14,13 @@ import org.springframework.core.io.ClassPathResource
 @Configuration
 class FirebaseConfig {
 
+    @Value("\${firebase.service-account-json}")
+    private lateinit var serviceAccountJson: String
+
     @PostConstruct
     fun initialize() {
         if (FirebaseApp.getApps().isEmpty()) {
-            ClassPathResource("firebase-service-account.json").inputStream.use { serviceAccount ->
+            ByteArrayInputStream(serviceAccountJson.toByteArray()).use { serviceAccount ->
                 val options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build()

--- a/finda-notification/src/main/resources/application.yml
+++ b/finda-notification/src/main/resources/application.yml
@@ -50,3 +50,6 @@ spring:
 
 passport:
   secret-key: ${PASSPORT_SECRET_KEY}
+
+firebase:
+  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON}


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
> 리뷰 시 참고할 점이 있다면 작성해주세요.
* Firebase 서비스 계정 JSON을 환경변수로 주입받도록 변경했습니다.
* FIREBASE_SERVICE_ACCOUNT_JSON` 환경변수가 xquare에 등록되어 있어야 정상 동작합니다.

---
### 👩‍💻 작업한 내용을 설명해주세요
> 기존에 `firebase-service-account.json` 파일을 classpath에서 직접 읽는 방식으로 구현되어 있어 배포 환경에서 해당 파일이 존재하지 않아 앱 기동 시 CrashLoopBackOff가 발생하고 있었습니다.

- `FirebaseConfig`에서 `ClassPathResource` 대신 `ByteArrayInputStream`으로 변경
- `@Value`를 통해 `FIREBASE_SERVICE_ACCOUNT_JSON` 환경변수에서 JSON을 직접 주입
- `application.yml`에 `firebase.service-account-json` 프로퍼티 추가

---
### 📸 결과물을 캡쳐해주세요
> 결과 화면을 첨부해주세요.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.
#66 