### PR TITLE
merge(#66) @Value 주입 실패로 인한 FirebaseConfig 초기화 오류 수정

### DIFF
--- a/finda-notification/src/main/kotlin/finda/findanotification/global/config/FirebaseConfig.kt
+++ b/finda-notification/src/main/kotlin/finda/findanotification/global/config/FirebaseConfig.kt
@@ -1,25 +1,25 @@
 package finda.findanotification.global.config
 
-import com.google.api.client.util.Value
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import jakarta.annotation.PostConstruct
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
 import java.io.ByteArrayInputStream
 
 /**
  * 앱 시작 시 서비스 계정 JSON으로 Firebase에 로그인하는 코드
  */
 @Configuration
-class FirebaseConfig {
-
-    @Value("\${firebase.service-account-json}")
-    private lateinit var serviceAccountJson: String
+class FirebaseConfig(
+    private val environment: Environment
+) {
 
     @PostConstruct
     fun initialize() {
         if (FirebaseApp.getApps().isEmpty()) {
+            val serviceAccountJson = environment.getRequiredProperty("firebase.service-account-json")
             ByteArrayInputStream(serviceAccountJson.toByteArray()).use { serviceAccount ->
                 val options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))


### PR DESCRIPTION
### ✨ 리뷰 시 참고 사항을 작성해주세요
`@Value`로 환경변수를 주입받는 방식에서 `Environment`를 직접 주입받는 방식으로 변경했습니다.
기존 방식에서 lateinit 초기화 실패가 발생했던 원인과 해결 방법을 아래 작업 내용에 설명했으니 참고 부탁드립니다.

---
### 👩‍💻 작업한 내용을 설명해주세요
**문제 원인**
`@Value("\${firebase.service-account-json}")`는 Spring이 Bean을 생성한 뒤 필드를 주입하는 방식입니다.
그런데 `@PostConstruct`는 Bean 생성 직후 바로 실행되기 때문에, 타이밍에 따라 `@Value` 주입이 완료되기 전에 `initialize()`가 호출될 수 있습니다.
이로 인해 `lateinit property serviceAccountJson has not been initialized` 예외가 발생하며 애플리케이션이 기동되지 않았습니다.

**해결 방법**
`@Value lateinit var` 대신 `Environment`를 생성자로 주입받아 `getRequiredProperty()`로 직접 값을 읽도록 변경했습니다.
생성자 주입은 Bean이 완전히 생성되기 전에 의존성이 먼저 주입되므로, `@PostConstruct` 실행 시점에 값이 항상 보장됩니다.

---
### 📸 결과물을 캡쳐해주세요
> 배포 후 정상 기동 확인 시 캡처 첨부 부탁드립니다.

---
### 🔗 관련 이슈 번호를 첨부하여주세요
> 이슈 번호를 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **정리(Chores)**
  * Firebase 초기화 구성 방식 개선으로 런타임 속성 관리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->